### PR TITLE
Fix build for Android 12 and Gradle Plugin Version 7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     signingConfigs {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,10 @@ android {
             signingConfig signingConfigs.release
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     aaptOptions {
         noCompress 'dll'
     }
@@ -34,7 +38,6 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/app/src/main/java/com/roydammarell/kotlinappwithxamarindependency/MainActivity.kt
+++ b/app/src/main/java/com/roydammarell/kotlinappwithxamarindependency/MainActivity.kt
@@ -2,11 +2,11 @@ package com.roydammarell.kotlinappwithxamarindependency
 
 import android.app.Activity
 import android.os.Bundle
+import android.widget.Button
 import android.widget.TextView
 import com.roydammarell.xamarin.ServiceFactory
 import com.roydammarell.xamarininterface.IExceptionService
 import com.roydammarell.xamarininterface.IHelloService
-import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : Activity() {
 
@@ -17,7 +17,7 @@ class MainActivity : Activity() {
         val helloView = findViewById<TextView>(R.id.helloView)
         helloView.text = helloService.createHello()
 
-        throwButton.setOnClickListener {
+        findViewById<Button>(R.id.throwButton).setOnClickListener {
             exceptionService.throwNullReferenceException()
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -26,6 +26,6 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-project.ext.compileSdkVersion = 30
+project.ext.compileSdkVersion = 31
 project.ext.minSdkVersion = 21
-project.ext.targetSdkVersion = 30
+project.ext.targetSdkVersion = 31

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/xamarin/build.gradle
+++ b/xamarin/build.gradle
@@ -71,21 +71,6 @@ dependencies {
     androidTestImplementation files(javaRuntimePath)
 
     api project(':xamarininterface')
-
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-
-    // Dependencies required to resolve build errors
-    implementation "androidx.transition:transition:1.3.1"
-    implementation "androidx.asynclayoutinflater:asynclayoutinflater:1.0.0"
-    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.1.0"
-    implementation "androidx.slidingpanelayout:slidingpanelayout:1.1.0"
-    implementation 'com.google.android.material:material:1.1.0'
-    // End
-
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
 task copyDebugBindingsJar(type: Jar) {

--- a/xamarin/build.gradle
+++ b/xamarin/build.gradle
@@ -3,7 +3,7 @@ import java.nio.file.Path
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-String xamarinTargetFrameworkVersion = 'v10.0' // Corresponds to compileSdkVersion
+String xamarinTargetFrameworkVersion = 'v12.0' // Corresponds to compileSdkVersion
 
 Path frameworksPath = new File('/Library/Frameworks').toPath()
 Path monoFrameworkPath = frameworksPath.resolve('Mono.framework/Versions/Current')
@@ -23,8 +23,6 @@ android {
     defaultConfig {
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -42,6 +40,8 @@ android {
                 exclude 'android/**'
             }
             resources.srcDirs objPath.resolve('Debug/android/bin/unpacked')
+            jniLibs.srcDirs = [objPath.resolve('Debug/android/bin/unpacked/lib')]
+            jni.srcDirs = []
         }
         release {
             java {
@@ -49,7 +49,13 @@ android {
                 exclude 'android/**'
             }
             resources.srcDirs objPath.resolve('Release/android/bin/unpacked')
+            jniLibs.srcDirs = [objPath.resolve('Release/android/bin/unpacked/lib')]
+            jni.srcDirs = []
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
@@ -80,7 +86,6 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 task copyDebugBindingsJar(type: Jar) {

--- a/xamarin/src/main/AndroidManifest.xml
+++ b/xamarin/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.roydammarell.xamarin">
 
-    <application>
+    <application
+        android:extractNativeLibs="false">
         <provider
             android:name="mono.MonoRuntimeProvider"
             android:exported="false"
@@ -9,7 +10,8 @@
             android:initOrder="2147483647" />
 
         <receiver
-            android:name="mono.android.Seppuku">
+            android:name="mono.android.Seppuku"
+            android:exported="false">
 
             <intent-filter>
 

--- a/xamarininterface/build.gradle
+++ b/xamarininterface/build.gradle
@@ -6,8 +6,6 @@ android {
     defaultConfig {
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -15,6 +13,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/xamarininterface/build.gradle
+++ b/xamarininterface/build.gradle
@@ -22,11 +22,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 repositories {


### PR DESCRIPTION
This Pull-Request contains fixes for the issues I've encountered when trying to build this project for Android 12.
Most notably I had to explicitly add `jniLibs.srcDirs` in xamarin module in order to include the native mono libraries into the final apk.
I also removed some usused / deprecated dependencies from the modules.