### PR TITLE
Fix build for Xamarin Android v12.0 and release build minification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    aaptOptions {
-        noCompress 'dll'
+    androidResources {
+        noCompress = ['dll', '.blob']
     }
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,18 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# xamarin integration
+-keep class mono.MonoRuntimeProvider { *; <init>(...); }
+-keep class mono.MonoPackageManager { *; <init>(...); }
+-keep class mono.MonoPackageManager_Resources { *; <init>(...); }
+-keep class mono.android.** { *; <init>(...); }
+-keep class mono.java.** { *; <init>(...); }
+-keep class mono.javax.** { *; <init>(...); }
+
+-keep class android.runtime.** { <init>(***); }
+-keep class assembly_mono_android.android.runtime.** { <init>(***); }
+-keep class com.xamarin.java_interop.** { *; }
+# hash for android.runtime and assembly_mono_android.android.runtime.
+-keep class md52ce486a14f4bcd95899665e9d932190b.** { *; <init>(...); }
+-keepclassmembers class md52ce486a14f4bcd95899665e9d932190b.** { *; <init>(...); }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+android.useNewApkCreator=false
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/xamarin/build.gradle
+++ b/xamarin/build.gradle
@@ -148,6 +148,9 @@ class UnpackXamarinApk extends Copy {
 afterEvaluate {
     tasks.clean.dependsOn cleanXamarin
 
+    tasks.mergeDebugJniLibFolders.dependsOn unpackDebugXamarin
+    tasks.mergeReleaseJniLibFolders.dependsOn unpackReleaseXamarin
+
     tasks.compileDebugKotlin.dependsOn unpackDebugXamarin
     tasks.compileReleaseKotlin.dependsOn unpackReleaseXamarin
 


### PR DESCRIPTION
This PR fixes 3 things (maybe I should have opened 3 separate ones...):

1.) Xamarin Android v12.0 changed the way the assemblies are packaged from multiple .dlls to a single .blob file.
I added this .blob file to the list of "noCompress" files, so the Mono code can load them correctly.

2.) After every `./gradlew clean` the first build didn't include all necessary internal Xamarin `.so` files. The second build always contained them. I tracked down the issue to a timing problem of the gradle build not waiting for these files to be unpacked from the Xamarin.Application apk. I was able to fix it with two more task dependencies.

3.) Fixes #8 and enables minified release builds. Until Google releases the Android Gradle Plugin 7.4.0 as stable this has to be done via the `android.useNewApkCreator=false` flag in `gradle.properties`. After upgrading to 7.4.0+ the [issue](https://issuetracker.google.com/issues/233102273) should be fixed without this flag.